### PR TITLE
Update old components to use middleclass

### DIFF
--- a/components/graphic/Drawable.lua
+++ b/components/graphic/Drawable.lua
@@ -1,6 +1,6 @@
 Drawable = class("Drawable")
 
-function Drawable:__init(image, r, sx, sy, ox, oy)
+function Drawable:initialize(image, r, sx, sy, ox, oy)
     self.image = image
     self.r = r
     if sx then self.sx = sx  end

--- a/components/graphic/DrawablePolygon.lua
+++ b/components/graphic/DrawablePolygon.lua
@@ -1,6 +1,6 @@
 DrawablePolygon = class("DrawablePolygon")
 
-function DrawablePolygon:__init(wold, x, y, l, h, type, entity)
+function DrawablePolygon:initialize(wold, x, y, l, h, type, entity)
     self.body = love.physics.newBody(world, x, y, type)
     self.shape = love.physics.newRectangleShape(l, h)
     self.fixture = love.physics.newFixture(self.body, self.shape)

--- a/components/identifier/IsCircle.lua
+++ b/components/identifier/IsCircle.lua
@@ -1,4 +1,4 @@
 IsCircle = class("IsCircle" , Component)
 
-function IsCircle:__init()
+function IsCircle:initialize()
 end

--- a/components/logic/Timing.lua
+++ b/components/logic/Timing.lua
@@ -1,5 +1,5 @@
 Timing = class("Timing", Component)
 
-function Timing:__init(time)
+function Timing:initialize(time)
 	self.timer = time
 end

--- a/components/particle/Particle.lua
+++ b/components/particle/Particle.lua
@@ -1,5 +1,5 @@
 Particle = class("Particle")
 
-function Particle:__init(image, buffer)
+function Particle:initialize(image, buffer)
     self.particle = love.graphics.newParticleSystem(image, buffer)
 end

--- a/components/particle/ParticleTimerComponent.lua
+++ b/components/particle/ParticleTimerComponent.lua
@@ -1,6 +1,6 @@
 ParticleTimerComponent = class("ParticleTimerComponent", Component)
 
-function ParticleTimerComponent:__init(particlelife, emitterlife)
+function ParticleTimerComponent:initialize(particlelife, emitterlife)
     self.particlelife = particlelife + 0.2
     self.emitterlife = emitterlife
 end

--- a/components/physic/Physic.lua
+++ b/components/physic/Physic.lua
@@ -1,6 +1,6 @@
 Physic = class("Physic", Component)
 
-function Physic:__init(body, fixture, shape)
+function Physic:initialize(body, fixture, shape)
     self.body = body
     self.shape = shape
     self.fixture = fixture

--- a/components/physic/Position.lua
+++ b/components/physic/Position.lua
@@ -1,6 +1,6 @@
 Position = class("Position", Component)
 
-function Position:__init(x, y)
+function Position:initialize(x, y)
     self.x = x
     self.y = y
 end

--- a/events/KeyPressed.lua
+++ b/events/KeyPressed.lua
@@ -1,6 +1,6 @@
 KeyPressed = class("KeyPressed")
 
-function KeyPressed:__init(key, isrepeat)
+function KeyPressed:initialize(key, isrepeat)
     self.key = key
     self.u = u
 end

--- a/events/MousePressed.lua
+++ b/events/MousePressed.lua
@@ -1,6 +1,6 @@
 MousePressed = class("MousePressed")
 
-function MousePressed:__init(x, y, button)
+function MousePressed:initialize(x, y, button)
     self.button = button
     self.y = y
     self.x = x


### PR DESCRIPTION
Was just checking out lovetoys and couldn't get the example to work..
Looks like when it was shifted over to use `middleclass` the components in the example weren't updated.