### PR TITLE
Replace undefined `u` variable in KeyPressed

### DIFF
--- a/events/KeyPressed.lua
+++ b/events/KeyPressed.lua
@@ -2,5 +2,5 @@ KeyPressed = class("KeyPressed")
 
 function KeyPressed:initialize(key, isrepeat)
     self.key = key
-    self.u = u
+    self.isrepeat = isrepeat
 end


### PR DESCRIPTION
I'm new to lovetoys so perhaps this is being used somewhere, in which case feel free to close, but for me, `u` was `nil` every time this function was called.